### PR TITLE
ristruttura script andamento_epidemia

### DIFF
--- a/scripts/andamento_epidemia.py
+++ b/scripts/andamento_epidemia.py
@@ -9,9 +9,8 @@ from custom.plots import update_labels
 from custom.preprocessing_dataframe import compute_incidence
 from custom.watermarks import add_watermark
 
-
 # funzioni per il plot
-def which_axe(x):
+def which_axe(x, axes, x_date, x_label):
     axes[x].set_xticks(x_date)
     axes[x].set_xlabel("")
     axes[x].set_xticklabels(x_label)
@@ -19,143 +18,163 @@ def which_axe(x):
     axes[x].grid()
 
 
-# Set work directory for the script
-scriptpath = path.dirname(path.realpath(__file__))
-chdir(scriptpath)
-
-# Set locale to "it" to parse the month correctly
-locale.setlocale(locale.LC_ALL, "it_IT.UTF-8")
-
-# plt.style.use("default")
-plt.style.use("seaborn-dark")
-
-""" Importa dati dell"Istituto Superiore di Sanità
+def load_data():
+    """ Importa dati dell"Istituto Superiore di Sanità
 Questi dati sono ricavati dai bollettini settimanali dell"ISS. Vedi ad esempio:
 epicentro.iss.it/coronavirus/bollettino/Bollettino-sorveglianza-integrata-COVID-19_15-settembre-2021.pdf
 """
+    df_assoluti = pd.read_csv("../dati/dati_ISS_complessivi.csv", sep=";")
 
-df_assoluti = pd.read_csv("../dati/dati_ISS_complessivi.csv", sep=";")
+    """ Elaborazione dati """
 
-""" Elaborazione dati """
+    # Calcola tassi di infezione, ospedalizzazione e decessi
+    # per vaccinati e non vaccinati
 
-# Calcola tassi di infezione, ospedalizzazione e decessi
-# per vaccinati e non vaccinati
+    # ricava i tassi, dividendo per la popolazione vaccinati e non vaccinata
+    df_tassi = compute_incidence(df_assoluti)
+    df_tassi.index = pd.to_datetime(df_assoluti["data"], format="%Y/%m/%d")
 
-# ricava i tassi, dividendo per la popolazione vaccinati e non vaccinata
-df_tassi = compute_incidence(df_assoluti)
-df_tassi.index = pd.to_datetime(df_assoluti["data"], format="%Y/%m/%d")
-
-# Calcola i numeri assoluti (medi, giornalieri) dell"epidemia
-df_assoluti2 = df_assoluti.copy(deep=True)
-df_assoluti2.index = pd.to_datetime(df_assoluti2["data"], format="%Y/%m/%d")
-df_assoluti2.drop("data", axis=1, inplace=True)
-# trasforma in numeri settimanali
-df_assoluti2 = (1/30)*df_assoluti2
+    # Calcola i numeri assoluti (medi, giornalieri) dell"epidemia
+    df_assoluti2 = df_assoluti.copy(deep=True)
+    df_assoluti2.index = pd.to_datetime(df_assoluti2["data"], format="%Y/%m/%d")
+    df_assoluti2.drop("data", axis=1, inplace=True)
+    # trasforma in numeri settimanali
+    df_assoluti2 = (1/30)*df_assoluti2
+    
+    return df_tassi, df_assoluti2
 
 """ Rappresentazione grafica dei risultati """
 
-# colori per plot vaccinati/non vaccinati
-palette = ["tab:red", "tab:green"]
+def plot_incidenza(x_date, x_label, show=False):
+    plt.style.use("seaborn-dark")
+    """ Tassi di infezione, ricovero, decesso """
+    fig, axes2 = plt.subplots(nrows=2, ncols=2, figsize=(7.5, 7.5))
 
-""" Tassi di infezione, ricovero, decesso """
+    # unpack all the axes subplots
+    axes = axes2.ravel()
+    
+    # colori per plot vaccinati/non vaccinati
+    palette = ["tab:red", "tab:green"]
 
-x_date = ["2021-07-01", "2021-08-01", "2021-09-01"]
-x_label = ["\nLug\n21", "\nAgo", "\nSet"]
+    df_tassi.iloc[:, [0, 1]].plot(ax=axes[0], marker="o", color=palette)
+    axes[0].set_title("Incidenza settimanale dei nuovi casi")
+    axes[0].set_ylabel("Ogni 100.000 persone per ciascun gruppo")
+    which_axe(0, axes, x_date, x_label)
 
-x_date, x_label = update_labels(df_tassi, x_date, x_label)
+    df_tassi.iloc[:, [2, 3]].plot(ax=axes[1], marker="o", color=palette)
+    axes[1].set_title("Incidenza settimanale degli ospedalizzati")
+    axes[1].set_ylabel("Ogni 100.000 persone per ciascun gruppo")
+    which_axe(1, axes, x_date, x_label)
 
-fig, axes2 = plt.subplots(nrows=2, ncols=2, figsize=(7.5, 7.5))
+    df_tassi.iloc[:, [4, 5]].plot(ax=axes[2], marker="o", color=palette)
+    axes[2].set_title("Incidenza settimanale dei ricoverati in TI")
+    axes[2].set_ylabel("Ogni 100.000 persone per ciascun gruppo")
+    which_axe(2, axes, x_date, x_label)
 
-# unpack all the axes subplots
-axes = axes2.ravel()
+    df_tassi.iloc[:, [6, 7]].plot(ax=axes[3], marker="o", color=palette)
+    axes[3].set_title("Incidenza settimanale dei deceduti")
+    axes[3].set_ylabel("Ogni 100.000 persone per ciascun gruppo")
+    which_axe(3, axes, x_date, x_label)
 
-df_tassi.iloc[:, [0, 1]].plot(ax=axes[0], marker="o", color=palette)
-axes[0].set_title("Incidenza settimanale dei nuovi casi")
-axes[0].set_ylabel("Ogni 100.000 persone per ciascun gruppo")
-which_axe(0)
+    # add watermarks
+    ax = plt.gca()
+    add_watermark(fig, ax.xaxis.label.get_fontsize())
 
-df_tassi.iloc[:, [2, 3]].plot(ax=axes[1], marker="o", color=palette)
-axes[1].set_title("Incidenza settimanale degli ospedalizzati")
-axes[1].set_ylabel("Ogni 100.000 persone per ciascun gruppo")
-which_axe(1)
+    plt.tight_layout()
+    plt.savefig("../risultati/andamento_epidemia.png",
+                dpi=300,
+                bbox_inches="tight")
+    
+    if show==True:
+        plt.show()
 
-df_tassi.iloc[:, [4, 5]].plot(ax=axes[2], marker="o", color=palette)
-axes[2].set_title("Incidenza settimanale dei ricoverati in TI")
-axes[2].set_ylabel("Ogni 100.000 persone per ciascun gruppo")
-which_axe(2)
 
-df_tassi.iloc[:, [6, 7]].plot(ax=axes[3], marker="o", color=palette)
-axes[3].set_title("Incidenza settimanale dei deceduti")
-axes[3].set_ylabel("Ogni 100.000 persone per ciascun gruppo")
-which_axe(3)
+def plot_rapporto_tassi(x_date, x_label, show=False):
+    plt.style.use("seaborn-dark")
+    """ Rapporto fra tassi """
+    fig = plt.figure(figsize=(6, 5))
+    (df_tassi.iloc[:, 0]/df_tassi.iloc[:, 1]).plot(label="Nuovi casi",
+                                                   color="blue")
+    (df_tassi.iloc[:, 2]/df_tassi.iloc[:, 3]).plot(label="Ospedalizzazione",
+                                                   color="green")
+    (df_tassi.iloc[:, 4]/df_tassi.iloc[:, 5]).plot(label="Ricovero in TI",
+                                                   color="red")
+    (df_tassi.iloc[:, 6]/df_tassi.iloc[:, 7]).plot(label="Decesso",
+                                                   color="gray")
+    plt.title("Rapporto fra le incidenze")
+    plt.ylabel("Non vaccinati/vaccinati")
+    plt.xlabel("")
+    plt.xticks(x_date, x_label)
+    plt.legend()
+    plt.grid()
+    plt.tight_layout()
 
-# add watermarks
-ax = plt.gca()
-add_watermark(fig, ax.xaxis.label.get_fontsize())
+    # add watermarks
+    ax = plt.gca()
+    add_watermark(fig, ax.xaxis.label.get_fontsize())
 
-plt.tight_layout()
-plt.savefig("../risultati/andamento_epidemia.png",
-            dpi=300,
-            bbox_inches="tight")
-# plt.show()
+    plt.savefig("../risultati/rapporto_tra_tassi.png",
+                dpi=300,
+                bbox_inches="tight")
+    
+    if show==True:
+        plt.show()
 
-""" Rapporto fra tassi """
+def plot_num_assoluti(x_date, x_label, show=False):
+    plt.style.use("seaborn-dark")
+    """ Andamento dei numeri assoluti """
+    fig, axes2 = plt.subplots(nrows=2, ncols=2, figsize=(7.5, 7.5))
 
-fig = plt.figure(figsize=(6, 5))
-(df_tassi.iloc[:, 0]/df_tassi.iloc[:, 1]).plot(label="Nuovi casi",
-                                               color="blue")
-(df_tassi.iloc[:, 2]/df_tassi.iloc[:, 3]).plot(label="Ospedalizzazione",
-                                               color="green")
-(df_tassi.iloc[:, 4]/df_tassi.iloc[:, 5]).plot(label="Ricovero in TI",
-                                               color="red")
-(df_tassi.iloc[:, 6]/df_tassi.iloc[:, 7]).plot(label="Decesso",
-                                               color="gray")
-plt.title("Rapporto fra le incidenze")
-plt.ylabel("Non vaccinati/vaccinati")
-plt.xlabel("")
-plt.xticks(x_date, x_label)
-plt.legend()
-plt.grid()
-plt.tight_layout()
+    # unpack all the axes subplots
+    axes = axes2.ravel()
+    
+    # colori per plot vaccinati/non vaccinati
+    palette = ["tab:red", "tab:green"]
 
-# add watermarks
-ax = plt.gca()
-add_watermark(fig, ax.xaxis.label.get_fontsize())
+    df_assoluti2.iloc[:, [2, 3]].plot(ax=axes[0], marker="o", color=palette)
+    axes[0].set_title("Nuovi casi giornalieri \n(media mobile 30 gg)")
+    which_axe(0, axes, x_date, x_label)
 
-plt.savefig("../risultati/rapporto_tra_tassi.png",
-            dpi=300,
-            bbox_inches="tight")
-# plt.show()
+    df_assoluti2.iloc[:, [4, 5]].plot(ax=axes[1], marker="o", color=palette)
+    axes[1].set_title("Nuovi ospedalizzati giornalieri \n(media mobile 30 gg)")
+    which_axe(1, axes, x_date, x_label)
 
-""" Andamento dei numeri assoluti """
+    df_assoluti2.iloc[:, [6, 7]].plot(ax=axes[2], marker="o", color=palette)
+    axes[2].set_title("Nuovi ricoverati in TI giornalieri \n(media mobile 30 gg)")
+    which_axe(2, axes, x_date, x_label)
 
-fig, axes2 = plt.subplots(nrows=2, ncols=2, figsize=(7.5, 7.5))
+    df_assoluti2.iloc[:, [8, 9]].plot(ax=axes[3], marker="o", color=palette)
+    axes[3].set_title("Decessi giornalieri \n(media mobile 30 gg)")
+    which_axe(3, axes, x_date, x_label)
 
-# unpack all the axes subplots
-axes = axes2.ravel()
+    # add watermarks
+    ax = plt.gca()
+    add_watermark(fig, ax.xaxis.label.get_fontsize())
 
-df_assoluti2.iloc[:, [2, 3]].plot(ax=axes[0], marker="o", color=palette)
-axes[0].set_title("Nuovi casi giornalieri \n(media mobile 30 gg)")
-which_axe(0)
+    plt.tight_layout()
+    plt.savefig("../risultati/andamento_epidemia_num_assoluti.png",
+                dpi=300,
+                bbox_inches="tight")
+    
+    if show==True:
+        plt.show()
 
-df_assoluti2.iloc[:, [4, 5]].plot(ax=axes[1], marker="o", color=palette)
-axes[1].set_title("Nuovi ospedalizzati giornalieri \n(media mobile 30 gg)")
-which_axe(1)
+    
+if __name__ == "__main__":
+        
+    # Set work directory for the script
+    scriptpath = path.dirname(path.realpath(__file__))
+    chdir(scriptpath)
 
-df_assoluti2.iloc[:, [6, 7]].plot(ax=axes[2], marker="o", color=palette)
-axes[2].set_title("Nuovi ricoverati in TI giornalieri \n(media mobile 30 gg)")
-which_axe(2)
-
-df_assoluti2.iloc[:, [8, 9]].plot(ax=axes[3], marker="o", color=palette)
-axes[3].set_title("Decessi giornalieri \n(media mobile 30 gg)")
-which_axe(3)
-
-# add watermarks
-ax = plt.gca()
-add_watermark(fig, ax.xaxis.label.get_fontsize())
-
-plt.tight_layout()
-plt.savefig("../risultati/andamento_epidemia_num_assoluti.png",
-            dpi=300,
-            bbox_inches="tight")
-# plt.show()
+    # Set locale to "it" to parse the month correctly
+    locale.setlocale(locale.LC_ALL, "it_IT.UTF-8")
+      
+    x_date = ["2021-07-01", "2021-08-01", "2021-09-01", "2021-10-01"]
+    x_label = ["\nLug\n21", "\nAgo", "\nSet", "\nOtt"]
+    
+    df_tassi, df_assoluti2 = load_data()
+    x_date, x_label = update_labels(df_tassi, x_date, x_label)
+    
+    plot_incidenza(x_date, x_label)
+    plot_rapporto_tassi(x_date, x_label)
+    plot_num_assoluti(x_date, x_label)


### PR DESCRIPTION
Per convertire da Notebook a Python script, sarebbe meglio utilizzare una struttura di questo tipo:

- importare tutti i pacchetti necessari
- dichiarare tutte le funzioni
- infine chiamare le funzioni 

Attualmente la struttura è molto simile a quella che c'era nel Notebook, ma in uno script è più difficile da leggere 